### PR TITLE
Fix dispatch handlers

### DIFF
--- a/js/actions/actions.js
+++ b/js/actions/actions.js
@@ -53,5 +53,14 @@ module.exports = {
         replaceWith: edits.replaceWith
       }
     });
+  },
+
+  flashNotify: function(message) {
+    AppDispatcher.dispatch({
+      type: ActionTypes.NOTIFY,
+      data: {
+        message: message
+      }
+    });
   }
 };

--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -6,6 +6,7 @@ module.exports = {
     RENAME_LOCAL_USER: null,
     CHANGE_SETTING: null,
     CLEAR_FLASH: null,
-    EDIT_LAST_MESSAGE: null
+    EDIT_LAST_MESSAGE: null,
+    NOTIFY: null
   })
 };

--- a/js/stores/flash_store.js
+++ b/js/stores/flash_store.js
@@ -13,7 +13,7 @@ var FlashStore = assign({}, EventEmitter.prototype, {
 
 });
 
-var DispatchHandler = {}
+var DispatchHandler = {};
 
 DispatchHandler[ActionTypes.CHANGE_SETTING] = function(data) {
   AppDispatcher.waitFor([SettingsStore.dispatchToken]);
@@ -24,9 +24,15 @@ DispatchHandler[ActionTypes.CLEAR_FLASH] = function() {
   _message = '';
 };
 
+DispatchHandler[ActionTypes.NOTIFY] = function(data) {
+  _message = data.message;
+};
+
 FlashStore.dispatchToken = AppDispatcher.register(function(action) {
-  DispatchHandler[action.type](action.data);
-  FlashStore.emit('change');
+  if (DispatchHandler.hasOwnProperty(action.type)) {
+    DispatchHandler[action.type](action.data);
+    FlashStore.emit('change');
+  }
 });
 
 module.exports = FlashStore;

--- a/js/stores/message_store.js
+++ b/js/stores/message_store.js
@@ -61,7 +61,9 @@ DispatchHandler[ActionTypes.EDIT_LAST_MESSAGE] = function(data) {
 };
 
 MessageStore.dispatchToken = AppDispatcher.register(function(action) {
-   DispatchHandler[action.type](action.data);
-   MessageStore.emit('change');
+  if (DispatchHandler.hasOwnProperty(action.type)) {
+    DispatchHandler[action.type](action.data);
+    MessageStore.emit('change');
+  }
 });
 module.exports = MessageStore;

--- a/js/utils/user_command_handler.js
+++ b/js/utils/user_command_handler.js
@@ -47,6 +47,10 @@ module.exports = {
       }
     };
 
-    userCommandRouter[command]();
+    if (userCommandRouter.hasOwnProperty(command)) {
+      userCommandRouter[command]();
+    } else {
+      actions.flashNotify('Unknown command: ' + command);
+    }
   }
 };


### PR DESCRIPTION
So those last changes actually broke something... The dispatcher calls _all_ the callback for every action. So if the action type key wasn't present in the handler object an error was thrown. So I've added checks for those plush a notification if a user tries a command that doesn't exist.
