### PR TITLE
Add keys

### DIFF
--- a/js/components/channel_messages.jsx
+++ b/js/components/channel_messages.jsx
@@ -9,7 +9,7 @@ var ChannelMessages = React.createClass({
     var messageNodes = this.state.messages.map(function(message) {
       var displayTime = TimePresenter.presentMessageTime(message.timestamp, this.state.currentTime);
       return (
-        <Message message={message} displayTime={displayTime}>
+        <Message key={message.key} message={message} displayTime={displayTime}>
         </Message>
       );
     }.bind(this));
@@ -30,8 +30,8 @@ var ChannelMessages = React.createClass({
 
   componentDidMount: function() {
     MessageStore.on('change', this._messageStoreChange);
-    Actions.loadChannelMessages('bestcohort'); // TODO use channel name
-    Actions.listenForNewMessages('bestcohort');
+    Actions.listenForNewMessages('bestcohort'); // TODO use channel name
+
     this._startClock();
   },
 

--- a/js/components/channel_users.jsx
+++ b/js/components/channel_users.jsx
@@ -3,9 +3,9 @@ var UserStore = require('../stores/user_store');
 
 var ChannelUsers = React.createClass({
   render: function() {
-    names = this.state.users.map(function(user) {
+    names = this.state.users.map(function(user, index) {
       return(
-        <li>{user.name}</li>
+        <li key={index}>{user.name}</li>
       );
     });
     return(

--- a/js/data/data.js
+++ b/js/data/data.js
@@ -138,6 +138,7 @@ module.exports = {
         var messagesRef = FirebaseRef.child('messages/' + options.channel);
         messagesRef.on('child_added', function(snapshot) {
           var newMessage = snapshot.val();
+          newMessage.key = snapshot.key();
           options.success(newMessage);
         });
       }


### PR DESCRIPTION
Resolves https://github.com/rorysaur/quack/issues/26 I removed the loadChannelMessages call for now so that the messages only load once (though the fact that they load one at a time is pretty dumb). Not sure if we should get rid of loadChannelMessages and the accompanying code. We should think about ways we could get message loading to work as it should (so that we get all the old messages in one shot and then listen for new ones).

My one thought is storing the messages in an object (or a set https://github.com/facebook/immutable-js) with their keys as keys (in addition to storing them in an array) which would give us O(1) detection of old messages. Then we could check that the message was new before adding it to the store. Maybe this is something we would want to do anyway? The listenForNewMessages action could then be  a callback to the load messages action.

Alternatively, is my desire to have all the old messages come down at once just from having http instincts in this brave new WebSockets world? Does it matter?
