### PR TITLE
Optimism

### DIFF
--- a/js/actions/actions.js
+++ b/js/actions/actions.js
@@ -4,6 +4,7 @@ var QuackData = require('../data/data');
 var UserStore = require('../stores/user_store');
 var UserCommandHandler = require('../utils/user_command_handler');
 var SettingsStore = require('../stores/settings_store');
+var UUID = require('../utils/uuid');
 
 var dispatch = function(type, data) {
   AppDispatcher.dispatch({
@@ -21,7 +22,8 @@ module.exports = {
     var message = {
       text: text,
       timestamp: timestamp,
-      user: 'guest' // hard-code for now
+      user: 'guest', // hard-code for now
+      clientId: UUID.generate()
     };
 
     dispatch(ActionTypes.NEW_MESSAGE, message);
@@ -29,10 +31,13 @@ module.exports = {
     QuackData.create('message', {
       message: message,
       success: function() {
-        dispatch(ActionTypes.CREATE_MESSAGE_SUCCESS);
+        dispatch(ActionTypes.CREATE_MESSAGE_SUCCESS, message);
       },
       error: function(err) {
-        dispatch(ActionTypes.CREATE_MESSAGE_ERROR);
+        dispatch(
+          ActionTypes.CREATE_MESSAGE_ERROR,
+          {message: message, error: err}
+        );
         console.log(err);
       }
     });
@@ -67,7 +72,7 @@ module.exports = {
   },
 
   unlistenForNewMessages: function(channelName) {
-    QuackData.off('new_message', {
+    QuackData.off('message_created', {
       channel: channelName
     });
   },

--- a/js/actions/actions.js
+++ b/js/actions/actions.js
@@ -24,6 +24,8 @@ module.exports = {
       user: 'guest' // hard-code for now
     };
 
+    dispatch(ActionTypes.NEW_MESSAGE, message);
+
     QuackData.create('message', {
       message: message,
       success: function() {
@@ -37,11 +39,11 @@ module.exports = {
   },
 
   listenForNewMessages: function(channelName) {
-    QuackData.on('new_message', {
+    QuackData.on('message_created', {
       channel: channelName,
       success: function(message) {
         dispatch(
-          ActionTypes.NEW_MESSAGE,
+          ActionTypes.MESSAGE_CREATED,
           message
         );
       }

--- a/js/actions/actions.js
+++ b/js/actions/actions.js
@@ -26,7 +26,7 @@ module.exports = {
       clientId: UUID.generate()
     };
 
-    dispatch(ActionTypes.NEW_MESSAGE, message);
+    dispatch(ActionTypes.CREATE_MESSAGE, message);
 
     QuackData.create('message', {
       message: message,

--- a/js/actions/actions.js
+++ b/js/actions/actions.js
@@ -36,7 +36,10 @@ module.exports = {
       error: function(err) {
         dispatch(
           ActionTypes.CREATE_MESSAGE_ERROR,
-          {message: message, error: err}
+          {
+            message: message,
+            error: err
+          }
         );
         console.log(err);
       }

--- a/js/actions/actions.js
+++ b/js/actions/actions.js
@@ -44,11 +44,11 @@ module.exports = {
   },
 
   listenForNewMessages: function(channelName) {
-    QuackData.on('message_created', {
+    QuackData.on('incoming_message', {
       channel: channelName,
       success: function(message) {
         dispatch(
-          ActionTypes.MESSAGE_CREATED,
+          ActionTypes.INCOMING_MESSAGE,
           message
         );
       }
@@ -72,7 +72,7 @@ module.exports = {
   },
 
   unlistenForNewMessages: function(channelName) {
-    QuackData.off('message_created', {
+    QuackData.off('incoming_message', {
       channel: channelName
     });
   },

--- a/js/components/message.jsx
+++ b/js/components/message.jsx
@@ -4,12 +4,16 @@ var TimePresenter = require('../utils/time_presenter');
 var Message = React.createClass({
   render: function() {
     var message = this.props.message;
-    var className = (message.status === 'Pending') ? 'message pending' : 'message';
+    var time  = this.props.displayTime;
+    var className = 'message';
+    if (message.status === 'Pending' && time !== TimePresenter.initialTime) {
+      className = className + ' pending';
+    }
     return (
       <div className={className}>
         <div className="sender-stamp">
           <div className="message-sender">{message.user}</div>
-          <div className="message-time">{this.props.displayTime}</div>
+          <div className="message-time">{time}</div>
         </div>
         <div className="message-text">{message.text}</div>
       </div>

--- a/js/components/message.jsx
+++ b/js/components/message.jsx
@@ -4,8 +4,9 @@ var TimePresenter = require('../utils/time_presenter');
 var Message = React.createClass({
   render: function() {
     var message = this.props.message;
+    var className = (message.status === 'Pending') ? 'message pending' : 'message';
     return (
-      <div className="message">
+      <div className={className}>
         <div className="sender-stamp">
           <div className="message-sender">{message.user}</div>
           <div className="message-time">{this.props.displayTime}</div>

--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -2,11 +2,11 @@ var keyMirror = require('react/lib/keyMirror');
 
 module.exports = {
   ActionTypes: keyMirror({
+    CREATE_MESSAGE: null,
     CREATE_MESSAGE_SUCCESS: null,
     CREATE_MESSAGE_ERROR: null,
     LOAD_CHANNEL_MESSAGES_SUCCESS: null,
     LOAD_CHANNEL_MESSAGES_ERROR: null,
-    NEW_MESSAGE: null,
     RENAME_LOCAL_USER: null,
     CHANGE_SETTING: null,
     CLEAR_FLASH: null,

--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -11,7 +11,7 @@ module.exports = {
     CHANGE_SETTING: null,
     CLEAR_FLASH: null,
     EDIT_LAST_MESSAGE: null,
-    MESSAGE_CREATED: null,
+    INCOMING_MESSAGE: null,
     NOTIFY: null,
   })
 };

--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -11,6 +11,7 @@ module.exports = {
     CHANGE_SETTING: null,
     CLEAR_FLASH: null,
     EDIT_LAST_MESSAGE: null,
-    NOTIFY: null
+    MESSAGE_CREATED: null,
+    NOTIFY: null,
   })
 };

--- a/js/data/data.js
+++ b/js/data/data.js
@@ -101,7 +101,7 @@ module.exports = {
     }
 
     var handlers = {
-      message_created: function() {
+      incoming_message: function() {
         if (!options.channel) {
           console.log('No channel specified.');
           return;
@@ -124,7 +124,7 @@ module.exports = {
     }
 
     var handlers = {
-      message_created: function() {
+      incoming_message: function() {
         if (!options.channel) {
           console.log('No channel specified.');
           return;

--- a/js/data/data.js
+++ b/js/data/data.js
@@ -1,5 +1,5 @@
 var Firebase = require('firebase');
-var FirebaseUtils = require('../utils/firebase');
+var Help = require('../utils/help');
 
 // TODO put the uri in a constant / env var
 var FirebaseRef = new Firebase('https://quack.firebaseio.com');
@@ -75,7 +75,7 @@ module.exports = {
           'value',
           function(snapshot) {
             var messageObjs = snapshot.val();
-            var messages = FirebaseUtils.toArray(messageObjs);
+            var messages = Help.toArray(messageObjs);
             options.success(messages);
             return;
           },

--- a/js/data/data.js
+++ b/js/data/data.js
@@ -124,7 +124,7 @@ module.exports = {
     }
 
     var handlers = {
-      new_message: function() {
+      message_created: function() {
         if (!options.channel) {
           console.log('No channel specified.');
           return;

--- a/js/data/data.js
+++ b/js/data/data.js
@@ -101,7 +101,7 @@ module.exports = {
     }
 
     var handlers = {
-      new_message: function() {
+      message_created: function() {
         if (!options.channel) {
           console.log('No channel specified.');
           return;

--- a/js/stores/__tests__/message_store_test.js
+++ b/js/stores/__tests__/message_store_test.js
@@ -1,6 +1,7 @@
 jest.dontMock('../message_store');
 jest.dontMock('object-assign');
 jest.dontMock('react/lib/keyMirror');
+jest.dontMock('../../utils/help');
 
 describe('MessageStore', function() {
 

--- a/js/stores/__tests__/message_store_test.js
+++ b/js/stores/__tests__/message_store_test.js
@@ -10,14 +10,36 @@ describe('MessageStore', function() {
   
   var ActionTypes = require('../../constants/constants').ActionTypes;
 
+  var messageData = {
+    user: 'Ajax',
+    text: "Hello, everyone I'm nw.",
+    timestamp: new Date().getTime(),
+    local: true,
+    clientId: 'l34j32349d0sjdf1kl00.0dsofjdsfjdsp'
+  };
+
+  var incomingMessageData = {
+    user: 'Breakfast',
+    test: "Me too",
+    timestamp: new Date().getTime(),
+    clientId: 'sdif903409rjodfg02923.dsf9020934u8391'
+  };
+
   var actionCreateMessage = {
     type: ActionTypes.NEW_MESSAGE,
-    data: {
-      user: 'Bob',
-      text: "Hello, everyone I'm nw.",
-      timestamp: new Date().getTime(),
-      local: true
-    }
+    data: messageData
+  };
+
+  var actionCreateMessageSuccess = {
+    type: ActionTypes.CREATE_MESSAGE_SUCCESS,
+    data: messageData
+  };
+
+  var actionIncomingMessage = function(data) {
+    return {
+      type: ActionTypes.INCOMING_MESSAGE,
+      data: data
+    };
   };
 
   var actionEditLastMessage = {
@@ -42,6 +64,35 @@ describe('MessageStore', function() {
     var lastMessage = messages[messages.length - 1];
     expect(lastMessage.user).toBe(actionCreateMessage.data.user);
     expect(lastMessage.text).toBe(actionCreateMessage.data.text);
+  });
+
+  it('initially marks a new mesage as pending', function() {
+    callback(actionCreateMessage);
+    var message = MessageStore.all().pop();
+    expect(message.status).toBe("Pending");
+  });
+
+  it('it updates a messages to successful', function() {
+    callback(actionCreateMessage);
+    callback(actionCreateMessageSuccess);
+    var message = MessageStore.all().pop();
+    expect(message.status).toBe("Success");
+  });
+
+  it("it ignores incoming message for the client's own pending messages", function() {
+    callback(actionCreateMessage);
+    var messages = MessageStore.all();
+    var originalMessageCount = messages.length;
+    callback(actionIncomingMessage(messageData));
+    expect(MessageStore.all().length).toBe(originalMessageCount);
+  });
+
+  it('adds an incoming message if that message is not locally pending', function() {
+    callback(actionCreateMessage);
+    var messages = MessageStore.all();
+    var originalMessageCount = messages.length;
+    callback(actionIncomingMessage(incomingMessageData));
+    expect(MessageStore.all().length).toBe(originalMessageCount + 1);
   });
 
   it('edits the previous message', function() {

--- a/js/stores/__tests__/message_store_test.js
+++ b/js/stores/__tests__/message_store_test.js
@@ -26,7 +26,7 @@ describe('MessageStore', function() {
   };
 
   var actionCreateMessage = {
-    type: ActionTypes.NEW_MESSAGE,
+    type: ActionTypes.CREATE_MESSAGE,
     data: messageData
   };
 

--- a/js/stores/__tests__/message_store_test.js
+++ b/js/stores/__tests__/message_store_test.js
@@ -66,7 +66,7 @@ describe('MessageStore', function() {
     expect(lastMessage.text).toBe(actionCreateMessage.data.text);
   });
 
-  it('initially marks a new mesage as pending', function() {
+  it('initially marks a new message as pending', function() {
     callback(actionCreateMessage);
     var message = MessageStore.all().pop();
     expect(message.status).toBe("Pending");

--- a/js/stores/message_store.js
+++ b/js/stores/message_store.js
@@ -3,13 +3,13 @@ var assign = require('object-assign');
 var AppDispatcher = require('../dispatcher/app_dispatcher');
 var ActionTypes = require('../constants/constants').ActionTypes;
 
-var _successfulMessages = [];
+var _savedMessages = [];
 var _pendingMessages = {};
 
 var MessageStore = assign({}, EventEmitter.prototype, {
 
   all: function() {
-    var messages = _successfulMessages.concat(this.pending());
+    var messages = _savedMessages.concat(this.pending());
     var sorted = messages.sort(function(message1, message2) {
       return message1.timestamp - message2.timestamp;
     });
@@ -19,7 +19,7 @@ var MessageStore = assign({}, EventEmitter.prototype, {
 
   local: function() {
     var localMessages = [];
-    _successfulMessages.concat(this.pending()).forEach(function(message) {
+    _savedMessages.concat(this.pending()).forEach(function(message) {
       if (message.local === true) {
         localMessages.push(message);
       }
@@ -43,7 +43,7 @@ var MessageStore = assign({}, EventEmitter.prototype, {
 var DispatchHandler = {};
 
 DispatchHandler[ActionTypes.LOAD_CHANNEL_MESSAGES_SUCCESS] = function(messages) {
-  _successfulMessages = messages;
+  _savedMessages = messages;
 };
 
 DispatchHandler[ActionTypes.EDIT_LAST_MESSAGE] = function(data) {
@@ -65,12 +65,12 @@ DispatchHandler[ActionTypes.CREATE_MESSAGE] = function(message) {
 DispatchHandler[ActionTypes.CREATE_MESSAGE_SUCCESS] = function(message) {
   delete _pendingMessages[message.clientId];
   message.status = "Success";
-  _successfulMessages.push(message);
+  _savedMessages.push(message);
 };
 
 DispatchHandler[ActionTypes.INCOMING_MESSAGE] = function(message) {
   if (!_pendingMessages.hasOwnProperty(message.clientId)) { //Filter out local client messages
-    _successfulMessages.push(message);
+    _savedMessages.push(message);
   }
 };
 

--- a/js/stores/message_store.js
+++ b/js/stores/message_store.js
@@ -2,6 +2,7 @@ var EventEmitter = require('events').EventEmitter;
 var assign = require('object-assign');
 var AppDispatcher = require('../dispatcher/app_dispatcher');
 var ActionTypes = require('../constants/constants').ActionTypes;
+var Help = require('../utils/help');
 
 var _savedMessages = [];
 var _pendingMessages = {};
@@ -19,24 +20,17 @@ var MessageStore = assign({}, EventEmitter.prototype, {
 
   local: function() {
     var localMessages = [];
-    _savedMessages.concat(this.pending()).forEach(function(message) {
+    var all = _savedMessages.concat(this.pending())
+    all.forEach(function(message) {
       if (message.local === true) {
         localMessages.push(message);
       }
     });
-
     return localMessages;
   },
 
   pending: function() {
-    var messages = [];
-    for (var key in _pendingMessages) {
-      if (_pendingMessages.hasOwnProperty(key)) {
-        messages.push(_pendingMessages[key]);
-      }
-    }
-
-    return messages;
+    return Help.toArray(_pendingMessages);
   }
 });
 
@@ -56,7 +50,7 @@ DispatchHandler[ActionTypes.EDIT_LAST_MESSAGE] = function(data) {
 };
 
 DispatchHandler[ActionTypes.CREATE_MESSAGE] = function(message) {
-  var messageCopy = JSON.parse(JSON.stringify(message)); // Cloning the object
+  var messageCopy = Help.clone(message);
   messageCopy.status = "Pending";
   messageCopy.key = messageCopy.clientId;
   _pendingMessages[message.clientId] = messageCopy;

--- a/js/stores/message_store.js
+++ b/js/stores/message_store.js
@@ -19,14 +19,10 @@ var MessageStore = assign({}, EventEmitter.prototype, {
   },
 
   local: function() {
-    var localMessages = [];
-    var all = _savedMessages.concat(this.pending())
-    all.forEach(function(message) {
-      if (message.local === true) {
-        localMessages.push(message);
-      }
+    var all = _savedMessages.concat(this.pending());
+    return all.filter(function(message) {
+      return message.local === true;
     });
-    return localMessages;
   },
 
   pending: function() {

--- a/js/stores/message_store.js
+++ b/js/stores/message_store.js
@@ -32,7 +32,7 @@ var MessageStore = assign({}, EventEmitter.prototype, {
   pending: function() {
     var messages = [];
     for (var key in _pendingMessages) {
-      if (p.hasOwnProperty(key)) {
+      if (_pendingMessages.hasOwnProperty(key)) {
         messages.push(_pendingMessages[key]);
       }
     }
@@ -59,7 +59,7 @@ DispatchHandler[ActionTypes.EDIT_LAST_MESSAGE] = function(data) {
 DispatchHandler[ActionTypes.NEW_MESSAGE] = function(message) {
   message.status = "Pending";
   message.clientId = UUID.generate();
-  _pendingMessages.push(message);
+  _pendingMessages[message.clientId] = message;
 };
 
 DispatchHandler[ActionTypes.MESSAGE_CREATED] = function(message) {

--- a/js/stores/message_store.js
+++ b/js/stores/message_store.js
@@ -68,8 +68,8 @@ DispatchHandler[ActionTypes.CREATE_MESSAGE_SUCCESS] = function(message) {
   _successfulMessages.push(message);
 };
 
-DispatchHandler[ActionTypes.MESSAGE_CREATED] = function(message) {
-  if (!_pendingMessages.hasOwnProperty(message.clientId)) {
+DispatchHandler[ActionTypes.INCOMING_MESSAGE] = function(message) {
+  if (!_pendingMessages.hasOwnProperty(message.clientId)) { //Filter out local client messages
     _successfulMessages.push(message);
   }
 };

--- a/js/stores/message_store.js
+++ b/js/stores/message_store.js
@@ -55,8 +55,8 @@ DispatchHandler[ActionTypes.EDIT_LAST_MESSAGE] = function(data) {
   lastMessage.text = lastMessage.text.replace(data.find, data.replaceWith);
 };
 
-DispatchHandler[ActionTypes.NEW_MESSAGE] = function(message) {
-  messageCopy = JSON.parse(JSON.stringify(message)); // Cloning the object
+DispatchHandler[ActionTypes.CREATE_MESSAGE] = function(message) {
+  var messageCopy = JSON.parse(JSON.stringify(message)); // Cloning the object
   messageCopy.status = "Pending";
   messageCopy.key = messageCopy.clientId;
   _pendingMessages[message.clientId] = messageCopy;

--- a/js/utils/__tests__/help_test.js
+++ b/js/utils/__tests__/help_test.js
@@ -1,0 +1,26 @@
+jest.dontMock('../help');
+
+describe('Help', function() { 
+  var Help;
+  var testObject = {
+    name: 'Ajax',
+    skill: 'Jumping'
+  };
+
+  beforeEach(function() {
+    Help = require('../help');
+  });
+
+  it('converts object values to array', function() {
+    expect(Help.toArray(testObject)).toEqual(['Ajax', 'Jumping']);
+  });
+
+  it('clones objects', function() {
+    cloneObject = Help.clone(testObject);
+    expect(cloneObject).toEqual(testObject);
+    expect(cloneObject).toNotBe(testObject);
+    cloneObject.skill = 'Grey-eyed';
+    expect(testObject.skill).toNotBe('Grey-eyed');
+  });
+
+});

--- a/js/utils/__tests__/user_command_handler_test.js
+++ b/js/utils/__tests__/user_command_handler_test.js
@@ -16,7 +16,7 @@ describe('UserCommandHandler', function() {
   });
 
   it('triggers the changeSetting action with config', function() {
-    UserCommandHandler.handle(':config cmd /', Actions);
+    UserCommandHandler.handle(':set cmd /', Actions);
     expect(Actions.changeSetting.mock.calls[0][0]).toEqual({variable: 'cmd', value: '/'});
   });
 

--- a/js/utils/help.js
+++ b/js/utils/help.js
@@ -7,5 +7,9 @@ module.exports = {
       }
     }
     return results;
+  },
+
+  clone: function(obj) {
+    return JSON.parse(JSON.stringify(obj)); 
   }
 };

--- a/js/utils/time_presenter.js
+++ b/js/utils/time_presenter.js
@@ -61,7 +61,7 @@ var TimePresenter = {
     var seconds = milliseconds/1000;
     var minutes = Math.floor(seconds/60);
     if (minutes <= 1) {
-      return 'just meow';
+      return this.initialMessage;
     } else {
       return minutes + ' minutes ago';
     }
@@ -91,7 +91,9 @@ var TimePresenter = {
 
   _dateAndMonth: function(date) {
     return monthsOfTheYear[date.getMonth()] + ' ' + date.getDate();
-  }
+  },
+
+  initialMessage: 'just meow'
 };
 
 module.exports = TimePresenter;

--- a/js/utils/uuid.js
+++ b/js/utils/uuid.js
@@ -1,0 +1,9 @@
+var randomHex = function() {
+  return (Math.random() * 1000000000000).toString(16); 
+};
+
+module.exports = {
+  generate: function() {
+     return randomHex() + '-' + randomHex() + '-' + randomHex();
+  }
+};

--- a/stylesheets/message.scss
+++ b/stylesheets/message.scss
@@ -12,8 +12,11 @@
   padding: 5px;
   margin: 10px;
   @include border-radius(5px);
-  .send-stamp {
-  }
+}
+
+.pending {
+  border-style: dashed;
+  border-color: $red;
 }
 
 .message-sender {

--- a/stylesheets/message.scss
+++ b/stylesheets/message.scss
@@ -16,7 +16,7 @@
 
 .pending {
   border-style: dashed;
-  border-color: $red;
+  border-color: $orange;
 }
 
 .message-sender {


### PR DESCRIPTION
https://github.com/rorysaur/quack/issues/37

Summary:
- When an a message is created it gets a client id. This is just a large hexadecimal string.
- The NEW_MESSAGE event is triggered and the MessageStore adds the new message to a _pendingMessages object with it's clientId as the key. MessageStore emits change and the message is added to the ui.
- Simultaneously the new message is pushed to firebase. For whatever reason firebase fires the child_added before the push has been confirmed. I'm guessing they're trying to be helpful but I don't want to be tied to firebase if we don't have to and their helpfulness doesn't make it clear how we're supposed to be able to tell incoming from outgoing messages. Anyway, in the mean time we ignore the child_added for messages that are _pending. We still add them if they're coming from the server.
- Firebase confirms that the message was created and fires the MESSAGE_CREATED_SUCCESS event. The MessageStore then deletes the message from the _pendingMessages object (using the clientId) 
- There needs to be some indication of pending messages on the ui. Right now I gave them a red dashed border.

TODO: Get rid of the red dashed border. Seriously, thats terrible UI. Also, the pending indicator probably shouldn't show up until like a second has gone by (illustrating connection issues). Finally, need to handle the failure callback. Problem is: under what cirumstances would that get called? @rorysaur or anyone?

UPDATE: Fixed the pending indicator timing. Border is now orange?
